### PR TITLE
URL Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 *.war
 *.ear
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 .gradle

--- a/src/main/groovy/io/springframework/springboot/ci/SpringBootProductionBuildMaker.groovy
+++ b/src/main/groovy/io/springframework/springboot/ci/SpringBootProductionBuildMaker.groovy
@@ -42,7 +42,7 @@ class SpringBootProductionBuildMaker implements SpringBootNotification, JdkConfi
 						echo "Building service"
 						version=1.3.5.RELEASE
 						if [ ! -d "spring-$version" ]; then
-						  wget http://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version/spring-boot-cli-$version-bin.zip
+						  wget https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version/spring-boot-cli-$version-bin.zip
 						  unzip spring-boot-cli-$version-bin.zip
 						fi
 						spring-$version/bin/spring jar --exclude 'spring/**,start.jar' start.jar *.groovy

--- a/src/main/groovy/io/springframework/springio/ci/SpringStarterProductionBuildMaker.groovy
+++ b/src/main/groovy/io/springframework/springio/ci/SpringStarterProductionBuildMaker.groovy
@@ -42,7 +42,7 @@ class SpringStarterProductionBuildMaker implements SpringIoNotification, JdkConf
 						echo "Building service"
 						version=1.3.5.RELEASE
 						if [ ! -d "spring-$version" ]; then
-						  wget http://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version/spring-boot-cli-$version-bin.zip
+						  wget https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/$version/spring-boot-cli-$version-bin.zip
 						  unzip spring-boot-cli-$version-bin.zip
 						fi
 						spring-$version/bin/spring jar --exclude 'spring/**,start.jar' start.jar *.groovy


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://repo.spring.io/release/org/springframework/boot/spring-boot-cli/ with 2 occurrences migrated to:  
  https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/ ([https](https://repo.spring.io/release/org/springframework/boot/spring-boot-cli/) result 200).
* [ ] http://www.java.com/en/download/help/error_hotspot.xml with 1 occurrences migrated to:  
  https://www.java.com/en/download/help/error_hotspot.xml ([https](https://www.java.com/en/download/help/error_hotspot.xml) result 200).